### PR TITLE
Fix webhooks remove during initialization

### DIFF
--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -126,7 +126,6 @@ func (wrc *Register) Register() error {
 			return err
 		}
 	}
-	wrc.removeWebhookConfigurations()
 
 	caData := wrc.readCaData()
 	if caData == nil {
@@ -318,9 +317,12 @@ func (wrc *Register) createResourceMutatingWebhookConfiguration(caData []byte) e
 	_, err := wrc.client.CreateResource("", kindMutating, "", *config, false)
 	if errorsapi.IsAlreadyExists(err) {
 		logger.V(6).Info("resource mutating webhook configuration already exists", "name", config.Name)
+		err = wrc.updateMutatingWebhookConfiguration(config)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
-
 	if err != nil {
 		logger.Error(err, "failed to create resource mutating webhook configuration", "name", config.Name)
 		return err
@@ -344,6 +346,10 @@ func (wrc *Register) createResourceValidatingWebhookConfiguration(caData []byte)
 	_, err := wrc.client.CreateResource("", kindValidating, "", *config, false)
 	if errorsapi.IsAlreadyExists(err) {
 		logger.V(6).Info("resource validating webhook configuration already exists", "name", config.Name)
+		err = wrc.updateValidatingWebhookConfiguration(config)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -369,6 +375,10 @@ func (wrc *Register) createPolicyValidatingWebhookConfiguration(caData []byte) e
 	if _, err := wrc.client.CreateResource("", kindValidating, "", *config, false); err != nil {
 		if errorsapi.IsAlreadyExists(err) {
 			wrc.log.V(6).Info("webhook already exists", "kind", kindValidating, "name", config.Name)
+			err = wrc.updateValidatingWebhookConfiguration(config)
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -392,6 +402,10 @@ func (wrc *Register) createPolicyMutatingWebhookConfiguration(caData []byte) err
 	if _, err := wrc.client.CreateResource("", kindMutating, "", *config, false); err != nil {
 		if errorsapi.IsAlreadyExists(err) {
 			wrc.log.V(6).Info("webhook already exists", "kind", kindMutating, "name", config.Name)
+			err = wrc.updateMutatingWebhookConfiguration(config)
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -414,6 +428,10 @@ func (wrc *Register) createVerifyMutatingWebhookConfiguration(caData []byte) err
 	if _, err := wrc.client.CreateResource("", kindMutating, "", *config, false); err != nil {
 		if errorsapi.IsAlreadyExists(err) {
 			wrc.log.V(6).Info("webhook already exists", "kind", kindMutating, "name", config.Name)
+			err = wrc.updateMutatingWebhookConfiguration(config)
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -684,9 +702,6 @@ func (wrc *Register) checkEndpoint() error {
 		}
 	}
 
-	// clean up old webhook configurations, if any
-	wrc.removeWebhookConfigurations()
-
 	err = fmt.Errorf("endpoint not ready")
 	wrc.log.V(3).Info(err.Error(), "ns", config.KyvernoNamespace, "name", config.KyvernoServiceName)
 	return err
@@ -849,5 +864,95 @@ func (wrc *Register) updateResourceMutatingWebhookConfiguration(nsSelector map[s
 
 	wrc.log.V(3).Info("successfully updated mutatingWebhookConfigurations", "name", getResourceMutatingWebhookConfigName(wrc.serverIP))
 
+	return nil
+}
+
+// updateMutatingWebhookConfiguration updates an existing MutatingWebhookConfiguration with the rules provided by
+// the targetConfig. If the targetConfig doesn't provide any rules, the existing rules will be preserved.
+func (wrc *Register) updateMutatingWebhookConfiguration(targetConfig *admregapi.MutatingWebhookConfiguration) error {
+	// Fetch the existing webhook.
+	currentConfiguration, err := wrc.mwcLister.Get(targetConfig.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get %s %s: %v", kindMutating, targetConfig.Name, err)
+	}
+	// Create a map of the target webhooks.
+	targetWebhooksMap := make(map[string]admregapi.MutatingWebhook)
+	for _, w := range targetConfig.Webhooks {
+		targetWebhooksMap[w.Name] = w
+	}
+	// Update the webhooks.
+	newWebhooks := make([]admregapi.MutatingWebhook, 0)
+	for _, w := range currentConfiguration.Webhooks {
+		target, exist := targetWebhooksMap[w.Name]
+		if !exist {
+			continue
+		}
+		delete(targetWebhooksMap, w.Name)
+		// Update the webhook configuration
+		w.ClientConfig.URL = target.ClientConfig.URL
+		w.ClientConfig.Service = target.ClientConfig.Service
+		w.ClientConfig.CABundle = target.ClientConfig.CABundle
+		if target.Rules != nil {
+			// If the target webhook has rule definitions override the current.
+			w.Rules = target.Rules
+		}
+		newWebhooks = append(newWebhooks, w)
+	}
+	// Check if there are additional webhooks defined and add them.
+	for _, w := range targetWebhooksMap {
+		newWebhooks = append(newWebhooks, w)
+	}
+	// Update the current configuration.
+	currentConfiguration.Webhooks = newWebhooks
+	_, err = wrc.client.UpdateResource("", kindMutating, "", currentConfiguration, false)
+	if err != nil {
+		return err
+	}
+	wrc.log.V(3).Info("successfully updated mutatingWebhookConfigurations", "name", targetConfig.Name)
+	return nil
+}
+
+// updateValidatingWebhookConfiguration updates an existing ValidatingWebhookConfiguration with the rules provided by
+// the targetConfig. If the targetConfig doesn't provide any rules, the existing rules will be preserved.
+func (wrc *Register) updateValidatingWebhookConfiguration(targetConfig *admregapi.ValidatingWebhookConfiguration) error {
+	// Fetch the existing webhook.
+	currentConfiguration, err := wrc.vwcLister.Get(targetConfig.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get %s %s: %v", kindValidating, targetConfig.Name, err)
+	}
+	// Create a map of the target webhooks.
+	targetWebhooksMap := make(map[string]admregapi.ValidatingWebhook)
+	for _, w := range targetConfig.Webhooks {
+		targetWebhooksMap[w.Name] = w
+	}
+	// Update the webhooks.
+	newWebhooks := make([]admregapi.ValidatingWebhook, 0)
+	for _, w := range currentConfiguration.Webhooks {
+		target, exist := targetWebhooksMap[w.Name]
+		if !exist {
+			continue
+		}
+		delete(targetWebhooksMap, w.Name)
+		// Update the webhook configuration
+		w.ClientConfig.URL = target.ClientConfig.URL
+		w.ClientConfig.Service = target.ClientConfig.Service
+		w.ClientConfig.CABundle = target.ClientConfig.CABundle
+		if target.Rules != nil {
+			// If the target webhook has rule definitions override the current.
+			w.Rules = target.Rules
+		}
+		newWebhooks = append(newWebhooks, w)
+	}
+	// Check if there are additional webhooks defined and add them.
+	for _, w := range targetWebhooksMap {
+		newWebhooks = append(newWebhooks, w)
+	}
+	// Update the current configuration.
+	currentConfiguration.Webhooks = newWebhooks
+	_, err = wrc.client.UpdateResource("", kindValidating, "", currentConfiguration, false)
+	if err != nil {
+		return err
+	}
+	wrc.log.V(3).Info("successfully updated validatingWebhookConfigurations", "name", targetConfig.Name)
 	return nil
 }


### PR DESCRIPTION
During initialization the Kyverno leader Pod deletes all the
existing webhooks and recreates them. There is a small time window were
the cluster is not protected by the webhooks, allowing a user to apply
resources without any verfication.

